### PR TITLE
Submission checklist update + email variables in activity log

### DIFF
--- a/pprOjsPlugin/css/iqss.css
+++ b/pprOjsPlugin/css/iqss.css
@@ -45,6 +45,15 @@ div.pkpPublication__header div.pkpHeader__actions{
 /**
   SUBMISSION
  */
+#ppr_start_submissionChecklist label {
+	cursor: default;
+}
+
+#ppr_start_submissionChecklist ul {
+	list-style: revert;
+	padding: revert;
+}
+
 #ppr_confirmation_submissionChecklist {
 	font-size: .875rem;
 	line-height: 1.5rem;

--- a/pprOjsPlugin/services/PPRTemplateOverrideService.inc.php
+++ b/pprOjsPlugin/services/PPRTemplateOverrideService.inc.php
@@ -72,6 +72,7 @@ class PPRTemplateOverrideService {
         }
 
         if ($this->pprPlugin->getPluginSettings()->submissionConfirmationChecklistEnabled()) {
+            $this->overriddenTemplates[] = 'lib/pkp/templates/submission/form/step1.tpl';
             $this->overriddenTemplates[] = 'lib/pkp/templates/submission/form/step4.tpl';
         }
 

--- a/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
+++ b/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
@@ -94,7 +94,8 @@ class PPRFirstNameEmailService {
             error_log("PPR[PPRFirstNameEmailService] processing emailTemplate={$emailTemplate->emailKey}");
             $this->pprObjectFactory->firstNamesManagementService()->addFirstNamesToEmailTemplate($emailTemplate);
         } else {
-            error_log("PPR[PPRFirstNameEmailService] notSupported emailTemplate={$emailTemplate->emailKey}");
+            $emailKey = $emailTemplate->emailKey ?? 'N/A';
+            error_log("PPR[PPRFirstNameEmailService] notSupported emailTemplate={$emailKey}");
         }
 
         return false;

--- a/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
+++ b/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
@@ -49,7 +49,7 @@ class PPRFirstNameEmailService {
     private $pprPlugin;
     private $pprObjectFactory;
 
-    function __construct($plugin, $pprObjectFactory = null) {
+    public function __construct($plugin, $pprObjectFactory = null) {
         $this->pprPlugin = $plugin;
         $this->pprObjectFactory = $pprObjectFactory ?: new PPRObjectFactory();
         $this->pprPlugin->import('util.PPRMissingUser');
@@ -91,7 +91,10 @@ class PPRFirstNameEmailService {
     function addFirstNamesToEmailTemplate($hookName, $arguments) {
         $emailTemplate = $arguments[0];
         if ($emailTemplate instanceof SubmissionMailTemplate && $this->isEmailSupported($emailTemplate->emailKey)) {
+            error_log("PPR[PPRFirstNameEmailService] processing emailTemplate={$emailTemplate->emailKey}");
             $this->pprObjectFactory->firstNamesManagementService()->addFirstNamesToEmailTemplate($emailTemplate);
+        } else {
+            error_log("PPR[PPRFirstNameEmailService] notSupported emailTemplate={$emailTemplate->emailKey}");
         }
 
         return false;

--- a/pprOjsPlugin/templates/submission/form/step1.tpl
+++ b/pprOjsPlugin/templates/submission/form/step1.tpl
@@ -1,0 +1,116 @@
+{**
+ * templates/submission/form/step1.tpl
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * Step 1 of author submission process.
+ *}
+<script type="text/javascript">
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#submitStep1Form').pkpHandler('$.pkp.pages.submission.SubmissionStep1FormHandler');
+	{rdelim});
+</script>
+
+<form class="pkp_form" id="submitStep1Form" method="post" action="{url op="saveStep" path=$submitStep}">
+{csrf}
+{if $submissionId}<input type="hidden" name="submissionId" value="{$submissionId|escape}"/>{/if}
+	<input type="hidden" name="submissionChecklist" value="1"/>
+
+{include file="controllers/notification/inPlaceNotification.tpl" notificationId="submitStep1FormNotification"}
+
+{fbvFormArea id="submissionStep1"}
+
+	{$additionalFormContent1}
+
+	{include file="submission/submissionLocale.tpl"}
+
+	{$additionalFormContent2}
+
+	{include file="submission/form/categories.tpl"}
+
+	{* PPR SUBMISSION CHECKLIST OVERRIDE *}
+	{* REMOVE CHECKBOXES => JUST DISPLAY THE CHECKLIST *}
+	{if $currentContext->getLocalizedData('submissionChecklist')}
+		{fbvFormSection list="true" label="submission.submit.submissionChecklist" description="submission.submit.submissionChecklistDescription" id="ppr_start_submissionChecklist"}
+			{foreach name=checklist from=$currentContext->getLocalizedData('submissionChecklist') key=checklistId item=checklistItem}
+				<li>
+					<label>{$checklistItem.content|nl2br}</label>
+				</li>
+				{* CHECKLIST ITEMS ARE COMPULSORY AND VALIDATED IN THE BACKEND *}
+				{fbvElement type="hidden" id="checklist-$checklistId" value=1}
+			{/foreach}
+		{/fbvFormSection}
+	{/if}
+	{* PPR SUBMISSION CHECKLIST OVERRIDE END *}
+
+	{* Cover Note To Editor*}
+	{fbvFormSection for="commentsToEditor" title="submission.submit.coverNote"}
+		{fbvElement type="textarea" name="commentsToEditor" id="commentsToEditor" value=$commentsToEditor rich=true}
+	{/fbvFormSection}
+
+	{* Submitting in which role? *}
+	{if $noExistingRoles}
+		{if count($userGroupOptions) > 1}
+			{fbvFormSection label="submission.submit.availableUserGroups" description="submission.submit.availableUserGroupsDescription" list=true required=true}
+				{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
+					{if $defaultGroup->getId() == $userGroupId}{assign var="checked" value=true}{else}{assign var="checked" value=false}{/if}
+					{fbvElement type="radio" id="userGroup"|concat:$userGroupId name="userGroupId" value=$userGroupId checked=$checked label=$userGroupName translate=false}
+				{/foreach}
+			{/fbvFormSection}
+		{else}
+			{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
+				{capture assign="onlyUserGroupId"}{$userGroupId}{/capture}
+			{/foreach}
+			{fbvFormSection label="submission.submit.contactConsent" list=true required=true}
+				{fbvElement type="checkbox" id="userGroupId" required=true value=$onlyUserGroupId label="submission.submit.contactConsentDescription"}
+			{/fbvFormSection}
+		{/if}
+
+	{* If user has existing roles, show available roles or automatically select single role *}
+	{else}
+		{if count($userGroupOptions) > 1}
+			{fbvFormSection label="submission.submit.availableUserGroups" list=true required=true}
+				{if $managerGroups}
+					{translate key='submission.submit.userGroupDescriptionManagers' managerGroups=$managerGroups}
+				{else}
+					{translate key='submission.submit.userGroupDescription'}
+				{/if}
+				{foreach from=$userGroupOptions key="userGroupId" item="userGroupName"}
+					{if $defaultGroup->getId() == $userGroupId}{assign var="checked" value=true}{else}{assign var="checked" value=false}{/if}
+					{fbvElement type="radio" id="userGroup"|concat:$userGroupId name="userGroupId" value=$userGroupId checked=$checked label=$userGroupName translate=false}
+				{/foreach}
+			{/fbvFormSection}
+		{elseif count($userGroupOptions) == 1}
+			{foreach from=$userGroupOptions key="userGroupId" item="authorUserGroupName"}{assign var=userGroupId value=$userGroupId}{/foreach}
+			{fbvElement type="hidden" id="userGroupId" value=$userGroupId}
+		{/if}
+	{/if}
+
+	{if $copyrightNotice}
+		{fbvFormSection title="submission.submit.copyrightNoticeAgreementLabel"}
+			{$copyrightNotice}
+			{fbvFormSection list="true"}
+				{fbvElement type="checkbox" id="copyrightNoticeAgree" required=true value=1 label="submission.submit.copyrightNoticeAgree" checked=$submissionId}
+			{/fbvFormSection}
+		{/fbvFormSection}
+	{/if}
+
+	{* Privacy Statement *}
+	{if $hasPrivacyStatement}
+		{fbvFormSection list="true"}
+			{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+			{capture assign="privacyLabel"}{translate key="user.register.form.privacyConsent" privacyUrl=$privacyUrl}{/capture}
+			{fbvElement type="checkbox" id="privacyConsent" required=true value=1 label=$privacyLabel translate=false checked=$privacyConsent}
+		{/fbvFormSection}
+	{/if}
+
+	{* Buttons *}
+	{fbvFormButtons id="step1Buttons" submitText="common.saveAndContinue"}
+
+	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+{/fbvFormArea}
+
+</form>

--- a/pprOjsPlugin/tests/src/services/PPRTemplateOverrideServiceTest.php
+++ b/pprOjsPlugin/tests/src/services/PPRTemplateOverrideServiceTest.php
@@ -115,6 +115,7 @@ class PPRTemplateOverrideServiceTest extends PPRTestCase {
         ];
 
         $expectedTemplatesForSetting['submissionConfirmationChecklistEnabled'] = [
+            'lib/pkp/templates/submission/form/step1.tpl',
             'lib/pkp/templates/submission/form/step4.tpl',
         ];
 


### PR DESCRIPTION
Updated rendering of submission checklist to a bulleted point list in the first page of the submission workflow.

Updated FirstNameService to update activity log with the values of the first name email template variables.

