### PR TITLE
Added email variables documentation placeholder

### DIFF
--- a/docs/Sphinx-guides/source/developerGuide/useCases/emailTemplates.md
+++ b/docs/Sphinx-guides/source/developerGuide/useCases/emailTemplates.md
@@ -25,7 +25,7 @@ For all email templates [see](custom_email_templates)
 -``PPR_REQUESTED_REVIEWER_UNASSIGN`` is sent to the Reviewer when they haven’t responded, and it’s time to move on to another Reviewer. The Associate Editor clicks the "Unassign Reviewer" under the Reviewer's name
 
 ### Accepted Review Emails
-- ``PR_REVIEW_DUE_DATE_REVIEWER`` is a reminder sent to the Reviewer two days before their review is due
+- ``PPR_REVIEW_DUE_DATE_REVIEWER`` is a reminder sent to the Reviewer two days before their review is due
 - ``REVIEW_REMIND_ONECLICK`` is sent to the Reviewer when they have missed their review due date. The Associate Editors clicks the "Send Reminder" button next to a Reviewer's name
 - ``PPR_CONFIRMED_REVIEWER_UNASSIGN`` is sent to the Reviewer when they missed their review due date and it’s time to move on to another Reviewer. The Associate Editor clicks the "Cancel Reviewer” under the Reviewer's name
 - ``PPR_REVIEW_SUBMITTED`` is sent to the reviewer once they upload and click the "Submit Review" blue button

--- a/docs/Sphinx-guides/source/sysadminGuide/emailTemplateVariables.md
+++ b/docs/Sphinx-guides/source/sysadminGuide/emailTemplateVariables.md
@@ -1,0 +1,50 @@
+# Email Template Variables
+This is the list of backend variables available to the email templates to render dynamic data based in the workflow the email relates to.
+
+These variables can be used in the templates in the form ``{$variable_name}``
+
+## Backend classes
+Email variables added by ``FirstNameEmailService``:
+
+authorName, authorFullName, authorFirstName, contributorsNames,
+reviewerName, reviewerFullName, reviewerFirstName, firstNameOnly,
+editorName, editorFullName, editorFirstName
+
+Email variables added by ``SubmissionMailTemplate``:
+
+submissionTitle, submissionId, submissionAbstract, authorString, principalContactSignature, contextName, contextUrl, senderEmail, senderName, siteTitle
+
+Email Variables added by ``MailTemplate``:
+
+principalContactSignature, contextName, contextUrl, senderEmail, senderName, siteTitle
+
+## Descriptions
+
+| Email Template  | Variables                                                                        |
+|-----------------|----------------------------------------------------------------------------------|
+| ``NOTIFICATION`` |                                                                                  |
+| ``EDITOR_DECISION_INITIAL_DECLINE`` | ``FirstNameEmailService``, ``SubmissionMailTemplate``, authorName, submissionUrl |
+| ``EDITOR_DECISION_DECLINE`` | ``FirstNameEmailService``, ``SubmissionMailTemplate``, authorName, submissionUrl |
+| ``EDITOR_DECISION_REVISIONS`` | ``FirstNameEmailService``, ``SubmissionMailTemplate``, authorName, submissionUrl |
+| ``SUBMISSION_ACK`` |                                                                                  |
+| ``PPR_SUBMISSION_APPROVED`` |                                                                                  |
+| ``EDITOR_ASSIGN`` |                                                                                  |
+| ``REVIEW_REQUEST_ONECLICK`` |                                                                                  |
+| ``REVIEW_CONFIRM`` |                                                                                  |
+| ``REVIEW_DECLINE`` |                                                                                  |
+| ``PPR_REVIEW_ACCEPTED`` |                                                                                  |
+| ``PPR_REVIEW_DUE_DATE_REVIEWER`` |                                                                                  |
+| ``PPR_REVIEW_DUE_DATE_EDITOR`` |                                                                                  |
+| ``PPR_REVIEW_REQUEST_DUE_DATE_REVIEWER`` |                                                                                  |
+| ``REVIEW_REMIND_ONECLICK`` |                                                                                  |
+| ``PPR_REQUESTED_REVIEWER_UNASSIGN`` |                                                                                  |
+| ``PPR_CONFIRMED_REVIEWER_UNASSIGN`` |                                                                                  |
+| ``PPR_REVIEW_SUBMITTED`` |                                                                                  |
+| ``REVIEW_ACK`` |                                                                                  |
+| ``PPR_SUBMISSIONS_REPORT_TASK`` |                                                                                  |
+| ``PPR_REVIEW_SENT_AUTHOR`` |                                                                                  |
+| ``PPR_REVIEW_PENDING_WITH_FILES_REVIEWER`` |                                                                                  |
+| ``PPR_REVIEW_DUE_DATE_WITH_FILES_REVIEWER`` |                                                                                  |
+| ``PPR_SUBMISSION_CLOSED_AUTHOR`` |                                                                                  |
+| ``REVIEW_CANCEL`` |                                                                                  |
+

--- a/docs/Sphinx-guides/source/sysadminGuide/emailTemplates.md
+++ b/docs/Sphinx-guides/source/sysadminGuide/emailTemplates.md
@@ -10,15 +10,13 @@ In this section you will be able to access, add new templates or modify existing
 Each template will consist of the following fields:
 
 - Subject
-- From 
-- To
 - Content
 
 Each email template has its backend class.
 
 ## Adding an email template
 
-We have to be careful when importing or adding email templates, the field that contains the email template accepts rich format text and copying text from some editors can cause issues when these are parsed.
+We have to be careful when importing or adding text to email templates, the field that contains the email template accepts rich format text and copying text from some editors can cause issues when these are parsed.
 
 For a list of all the email templates please [see](custom_email_templates).
 

--- a/docs/Sphinx-guides/source/sysadminGuide/index.md
+++ b/docs/Sphinx-guides/source/sysadminGuide/index.md
@@ -14,6 +14,7 @@ This will increase the version number, update the PPR plugins version data, and 
 ```{toctree}
 users
 emailTemplates
+emailTemplateVariables
 environments
 config
 releases


### PR DESCRIPTION
Placeholder to add documentation for the email variables available in the most used templates in OJS.

This will be used by the OJS administrators to create email templates.

Closes SmartSheet#149