### PR TITLE
adding smtp monitor restart scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .DS_Store?
 .vscode
+.idea
 
 environment/data
 environment/config.inc.php

--- a/docs/Sphinx-guides/source/developerGuide/localEnvironment.md
+++ b/docs/Sphinx-guides/source/developerGuide/localEnvironment.md
@@ -78,6 +78,23 @@ smtp_port = 25
 smtp_suppress_cert_check = On
 ```
 
+#### Setting up a systemd service and timer to restart the SMTP service automatically if it goes down:
+
+Copy ppr-ojs/environment/monitoring/monitor-smtp.service and monitor-smtp.timer to /etc/systemd/system/ on the machine the smtp server is running
+
+Copy ppr-ojs/environment/monitoring/smtp-monitor.sh to your home directory on the machine the smtp server is running and give it execution permissions
+
+The default directory is /home/core/smtp-monitor.sh but can be changes by editing the monitor-smtp.service file
+
+Start the service:
+```
+sudo systemctl start monitor-smtp.timer
+```
+A log will be generated and can be viewed by:
+```
+cat /tmp/smtp-monitor
+```
+
 ## Clean the data directories
 To start the OJS application fresh, you will need to clean the DB and OJS files within the data directory.
 

--- a/environment/monitoring/monitor-smtp.service
+++ b/environment/monitoring/monitor-smtp.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Monitors SMTP docker container and restarts if not running
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sh -c '/home/core/smtp-monitor.sh >> /tmp/smtp-monitor'

--- a/environment/monitoring/monitor-smtp.timer
+++ b/environment/monitoring/monitor-smtp.timer
@@ -1,0 +1,5 @@
+[Unit]
+Description=Run monitor-smtp.service every 10 minutes
+
+[Timer]
+OnCalendar=*:0/10

--- a/environment/monitoring/smtp-monitor.sh
+++ b/environment/monitoring/smtp-monitor.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CONTAINER_NAME=iqss-smtp-ojs
+
+if docker ps | grep -q $CONTAINER_NAME; then
+  echo "$(date -u) running"
+else
+  echo "$(date -u) not running"
+  #docker start $CONTAINER_NAME
+  docker run --rm -itd --name $CONTAINER_NAME -p 1080:1080 -p 1025:1025 --env MAILDEV_SMTP_PORT=1025 --env MAILDEV_WEB_PORT=1080 --env MAILDEV_MAIL_DIRECTORY=/mail --mount type=tmpfs,destination=/mail maildev/maildev:2.0.5
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:  When the test SMTP service goes down it needs to be restarted manually. Monitoring and an automatic restart script is needed

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**: 

**Suggestions on how to test this**: Already running on core@199.94.61.168

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: included

**Additional documentation**: included