### PR TITLE
update monitor-smtp timer and documentation for reboot restart

### DIFF
--- a/docs/Sphinx-guides/source/developerGuide/localEnvironment.md
+++ b/docs/Sphinx-guides/source/developerGuide/localEnvironment.md
@@ -93,8 +93,9 @@ Copy ppr-ojs/environment/monitoring/smtp-monitor.sh to your home directory on th
 
 The default directory is /home/core/smtp-monitor.sh but can be changes by editing the monitor-smtp.service file
 
-Start the service:
+Start the service (and enable startup on reboot):
 ```
+sudo systemctl enable monitor-smtp.timer
 sudo systemctl start monitor-smtp.timer
 ```
 A log will be generated and can be viewed by:

--- a/environment/monitoring/monitor-smtp.timer
+++ b/environment/monitoring/monitor-smtp.timer
@@ -3,3 +3,6 @@ Description=Run monitor-smtp.service every 10 minutes
 
 [Timer]
 OnCalendar=*:0/10
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
**What this PR does / why we need it**: monitor-smtp.timer did not restart after a system reboot

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: running in test smtp server. 

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**: Docs are included

**Additional documentation**: