### PR TITLE
Fixed missing reviewer names in emails

### DIFF
--- a/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
+++ b/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
@@ -66,6 +66,8 @@ class PPRFirstNameEmailService {
             HookRegistry::register('TemplateManager::fetch', array($this, 'replaceFirstNameInTemplateText'));
 
             HookRegistry::register('advancedsearchreviewerform::display', array($this, 'addFirstNameLabelsToAdvancedSearchReviewerForm'));
+            HookRegistry::register('createreviewerform::display', array($this, 'addFirstNameLabelsToCreateReviewerForm'));
+            HookRegistry::register('createreviewerform::execute', array($this, 'addCreatedReviewerId'));
 
             HookRegistry::register('LoadComponentHandler', array($this, 'addPPRStageParticipantGridHandler'));
         }
@@ -107,6 +109,19 @@ class PPRFirstNameEmailService {
         $this->pprObjectFactory->firstNamesManagementService()->addFirstNameLabelsToTemplate('emailVariables');
 
         return false;
+    }
+
+    function addFirstNameLabelsToCreateReviewerForm($hookName, $arguments) {
+        $this->pprObjectFactory->firstNamesManagementService()->addFirstNameLabelsToTemplate('emailVariables');
+
+        return false;
+    }
+
+    function addCreatedReviewerId($hookName, $arguments) {
+        $form = $arguments[0];
+        $reviewerId = $form->getData('reviewerId');
+        $templateMgr = TemplateManager::getManager(Application::get()->getRequest());
+        $templateMgr->assign(['reviewerId' => $reviewerId]);
     }
 
     function addFirstNamesToThankReviewerForm($hookName, $arguments) {

--- a/pprOjsPlugin/util/PPRFirstNamesManagementService.inc.php
+++ b/pprOjsPlugin/util/PPRFirstNamesManagementService.inc.php
@@ -69,11 +69,15 @@ class PPRFirstNamesManagementService {
 
     public function getReviewer($reviewerId) {
         $request = Application::get()->getRequest();
+        $templateMgr = TemplateManager::getManager($request);
         $reviewer = null;
         if ($reviewerId) {
             $reviewer = $this->pprSubmissionUtil->getUser($reviewerId);
         } elseif ($reviewerId = $request->getUserVar('reviewerId')) {
             // TRY reviewerId REQUEST PARAMETER
+            $reviewer = $this->pprSubmissionUtil->getUser($reviewerId);
+        } elseif ($reviewerId = $templateMgr->getTemplateVars('reviewerId')) {
+            // TRY reviewerId IN TEMPLATE MANAGER
             $reviewer = $this->pprSubmissionUtil->getUser($reviewerId);
         } elseif ($reviewId = $request->getUserVar('reviewAssignmentId')) {
             // TRY reviewAssignment REQUEST PARAMETER


### PR DESCRIPTION
PR to fix missing reviewer first name in email templates when creating a new reviewer in the add reviewer flow.

This is just a fix for the issue.

Unit tests need to be fixed for the new code.