### PR TITLE
Add global email sender configuration and functionality

### DIFF
--- a/docs/Sphinx-guides/source/features.md
+++ b/docs/Sphinx-guides/source/features.md
@@ -63,6 +63,7 @@ Additionally, we use other plugins and customizations made by other contributors
 - Send submission approved confirmation email to author
 - Removes the Coauthors from the submission confirmation email the Author receives
 - Add a checkbox to allow authors to choose if contributors should be notified
+- Global email Sender
 
 ### Scheduled Tasks
 

--- a/pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php
+++ b/pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php
@@ -97,6 +97,10 @@ class PeerPreReviewProgramPlugin extends GenericPlugin {
             $addEditorEmailService = new PPRReviewAddEditorEmailService($this);
             $addEditorEmailService->register();
 
+            $this->import('services.email.PPREmailSenderOverwrite');
+            $addEditorEmailService = new PPREmailSenderOverwrite($this);
+            $addEditorEmailService->register();
+
             // THIS HOOK WILL ONLY BE CALLED WHEN THE acron PLUGIN IS RELOADED
             HookRegistry::register('AcronPlugin::parseCronTab', array($this, 'addScheduledTasks'));
         }

--- a/pprOjsPlugin/locale/en_US/locale.po
+++ b/pprOjsPlugin/locale/en_US/locale.po
@@ -80,6 +80,9 @@ msgstr "Send review submitted confirmation email to reviewer"
 msgid "plugins.generic.pprPlugin.settings.reviewReminderEmailOverrideEnabled.label"
 msgstr "Add review reminder action email template override based on review being accepted"
 
+msgid "plugins.generic.pprPlugin.settings.globalEmailSender.label"
+msgstr "Global email sender"
+
 msgid "plugins.generic.pprPlugin.settings.reviewAddEditorToBccEnabled.label"
 msgstr "Add Managing Editor as BCC to thank reviewer email"
 

--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Service to overwrite the senders email
+ *
+ */
+class PPREmailSenderOverwrite {
+
+    private $pprPlugin;
+
+    public function __construct($plugin) {
+        $this->pprPlugin = $plugin;
+    }
+
+    function register() {
+
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+
+        if (!empty($globalEmailSender)) {
+            HookRegistry::register('Mail::send', array($this, 'overwriteSender'));
+        }
+    }
+
+    /**
+     * Overwrite the sender of the email
+     */
+    function overwriteSender($hookName, $hookArgs) {
+        
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+
+        $mail = $hookArgs[0];
+        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        return false; 
+    }
+
+}

--- a/pprOjsPlugin/settings/PPRPluginSettings.inc.php
+++ b/pprOjsPlugin/settings/PPRPluginSettings.inc.php
@@ -63,6 +63,7 @@ class PPRPluginSettings {
 
         'accessKeyLifeTime' => ['int', 30],
         'fileUploadTextOverrideEnabled' => ['bool', null],
+        'globalEmailSender' => ['string', 'peerprereview@iq.harvard.edu'],
     );
     private $pprPlugin;
 
@@ -287,9 +288,12 @@ class PPRPluginSettings {
         return $this->getValue('reviewerSurveyHtml');
     }
 
-
     public function accessKeyLifeTime() {
         return $this->getValue('accessKeyLifeTime');
+    }
+
+    public function globalEmailSender() {
+        return $this->getValue('globalEmailSender');
     }
 
     private function getValue($propertyName) {

--- a/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
+++ b/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
@@ -93,6 +93,7 @@
 			{fbvElement type="checkbox" name="submissionApprovedEmailEnabled" label="plugins.generic.pprPlugin.settings.submissionApprovedEmailEnabled.label" id="submissionApprovedEmailEnabled" checked=$submissionApprovedEmailEnabled}
 			{fbvElement type="checkbox" name="submissionConfirmationContributorsEmailDisabled" label="plugins.generic.pprPlugin.settings.submissionConfirmationContributorsEmailDisabled.label" id="submissionConfirmationContributorsEmailDisabled" checked=$submissionConfirmationContributorsEmailDisabled}
 			{fbvElement type="checkbox" name="emailContributorsEnabled" label="plugins.generic.pprPlugin.settings.emailContributorsEnabled.label" id="emailContributorsEnabled" checked=$emailContributorsEnabled}
+			{fbvElement type="text" name="globalEmailSender" label="plugins.generic.pprPlugin.settings.globalEmailSender.label" id="globalEmailSender" value=$globalEmailSender}
 		{/fbvFormSection}
 
 		{fbvFormSection title="plugins.generic.pprPlugin.settings.section.tasks" list="true"}

--- a/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
+++ b/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
@@ -64,6 +64,7 @@ class PPRPluginSettingsTest extends PPRTestCase {
             'reviewerSurveyHtml' => [null, null],
             'accessKeyLifeTime' => [null, 30],
             'fileUploadTextOverrideEnabled' => [null, null],
+            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRPluginSettings::CONFIG_VARS as $configVar => $varInfo) {

--- a/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
+++ b/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
@@ -17,6 +17,7 @@ class PPRReportPluginSettingsTest extends PPRTestCase {
             // fieldName => [methodName, defaultValue]
             'submissionsReviewsReportEnabled' => [null, null],
             'submissionsReviewsReportRecipients' => [null, []],
+            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRReportPluginSettings::CONFIG_VARS as $configVar => $varInfo) {

--- a/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
+++ b/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
@@ -17,7 +17,6 @@ class PPRReportPluginSettingsTest extends PPRTestCase {
             // fieldName => [methodName, defaultValue]
             'submissionsReviewsReportEnabled' => [null, null],
             'submissionsReviewsReportRecipients' => [null, []],
-            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRReportPluginSettings::CONFIG_VARS as $configVar => $varInfo) {


### PR DESCRIPTION
This pull request introduces a new feature to set a global email sender for the `pprOjsPlugin`. The most important changes include adding a new service to overwrite the sender's email, updating the plugin settings to include the global email sender, and modifying the template to allow configuration of this new setting.

### New Feature: Global Email Sender

* [`pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php`](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1R1-R36): Added a new service class `PPREmailSenderOverwrite` to overwrite the sender's email. This class registers a hook to modify the sender's email address if a global email sender is configured.
* [`pprOjsPlugin/settings/PPRPluginSettings.inc.php`](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49R66): Updated the `PPRPluginSettings` class to include a new configuration variable `globalEmailSender` and added a method to retrieve its value. [[1]](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49R66) [[2]](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49L290-R298)
* [`pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php`](diffhunk://#diff-ded891a6c05034b7ad74ba80a5d88363e72b6e8c3afe486fd25f1c4fd37597ecR100-R103): Registered the new `PPREmailSenderOverwrite` service within the plugin's initialization process.
* [`pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl`](diffhunk://#diff-69b1417cd500e36cb657bd832c85dc6b4de23cca9e2e462a8b329ab5abd263b4R96): Modified the plugin settings form template to include a new text input for configuring the global email sender.
* [`pprOjsPlugin/locale/en_US/locale.po`](diffhunk://#diff-173adc05e1e6e91fe2ee1092fa2430ed0f75efd005dbd7126ec8fd8d9285fd5fR83-R85): Added a new localization string for the global email sender setting label.