### PR TITLE
Update email sender to use fixed address instead of global configuration

### DIFF
--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -14,7 +14,7 @@ class PPREmailSenderOverwrite {
 
     function register() {
 
-        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         if (!empty($globalEmailSender)) {
             HookRegistry::register('Mail::send', array($this, 'overwriteSender'));
@@ -26,10 +26,11 @@ class PPREmailSenderOverwrite {
      */
     function overwriteSender($hookName, $hookArgs) {
         
-        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         $mail = $hookArgs[0];
-        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        //$mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        $mail->setFrom('peerprereview@iq.harvard.edu', 'Peer Pre-Review');
         return false; 
     }
 


### PR DESCRIPTION
This pull request includes changes to the `pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php` file, specifically to the `register` and `overwriteSender` functions. The changes involve commenting out the retrieval of the global email sender from plugin settings and setting a hardcoded email sender instead.

Changes to email sender configuration:

* [`pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php`](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1L17-R17): Commented out the retrieval of the global email sender from plugin settings in the `register` and `overwriteSender` functions. [[1]](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1L17-R17) [[2]](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1L29-R33)
* [`pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php`](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1L29-R33): Set the email sender to 'peerprereview@iq.harvard.edu' with the name 'Peer Pre-Review' in the `overwriteSender` function.