### PR TITLE
Email sender overwrite

### DIFF
--- a/docs/Sphinx-guides/source/features.md
+++ b/docs/Sphinx-guides/source/features.md
@@ -63,6 +63,7 @@ Additionally, we use other plugins and customizations made by other contributors
 - Send submission approved confirmation email to author
 - Removes the Coauthors from the submission confirmation email the Author receives
 - Add a checkbox to allow authors to choose if contributors should be notified
+- Global email Sender
 
 ### Scheduled Tasks
 

--- a/pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php
+++ b/pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php
@@ -97,6 +97,10 @@ class PeerPreReviewProgramPlugin extends GenericPlugin {
             $addEditorEmailService = new PPRReviewAddEditorEmailService($this);
             $addEditorEmailService->register();
 
+            $this->import('services.email.PPREmailSenderOverwrite');
+            $addEditorEmailService = new PPREmailSenderOverwrite($this);
+            $addEditorEmailService->register();
+
             // THIS HOOK WILL ONLY BE CALLED WHEN THE acron PLUGIN IS RELOADED
             HookRegistry::register('AcronPlugin::parseCronTab', array($this, 'addScheduledTasks'));
         }

--- a/pprOjsPlugin/locale/en_US/locale.po
+++ b/pprOjsPlugin/locale/en_US/locale.po
@@ -80,6 +80,9 @@ msgstr "Send review submitted confirmation email to reviewer"
 msgid "plugins.generic.pprPlugin.settings.reviewReminderEmailOverrideEnabled.label"
 msgstr "Add review reminder action email template override based on review being accepted"
 
+msgid "plugins.generic.pprPlugin.settings.globalEmailSender.label"
+msgstr "Global email sender"
+
 msgid "plugins.generic.pprPlugin.settings.reviewAddEditorToBccEnabled.label"
 msgstr "Add Managing Editor as BCC to thank reviewer email"
 

--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -14,7 +14,7 @@ class PPREmailSenderOverwrite {
 
     function register() {
 
-        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         if (!empty($globalEmailSender)) {
             HookRegistry::register('Mail::send', array($this, 'overwriteSender'));
@@ -26,11 +26,11 @@ class PPREmailSenderOverwrite {
      */
     function overwriteSender($hookName, $hookArgs) {
         
-        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         $mail = $hookArgs[0];
-        //$mail->setFrom($globalEmailSender, 'Peer Pre-Review');
-        $mail->setFrom('peerprereview@iq.harvard.edu', 'Peer Pre-Review');
+        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        //$mail->setFrom('peerprereview@iq.harvard.edu', 'Peer Pre-Review');
         return false; 
     }
 

--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -30,7 +30,6 @@ class PPREmailSenderOverwrite {
 
         $mail = $hookArgs[0];
         $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
-        //$mail->setFrom('peerprereview@iq.harvard.edu', 'Peer Pre-Review');
         return false; 
     }
 

--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Service to overwrite the senders email
+ *
+ */
+class PPREmailSenderOverwrite {
+
+    private $pprPlugin;
+
+    public function __construct($plugin) {
+        $this->pprPlugin = $plugin;
+    }
+
+    function register() {
+
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+
+        if (!empty($globalEmailSender)) {
+            HookRegistry::register('Mail::send', array($this, 'overwriteSender'));
+        }
+    }
+
+    /**
+     * Overwrite the sender of the email
+     */
+    function overwriteSender($hookName, $hookArgs) {
+        
+        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+
+        $mail = $hookArgs[0];
+        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        return false; 
+    }
+
+}

--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -14,7 +14,7 @@ class PPREmailSenderOverwrite {
 
     function register() {
 
-        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         if (!empty($globalEmailSender)) {
             HookRegistry::register('Mail::send', array($this, 'overwriteSender'));
@@ -26,10 +26,11 @@ class PPREmailSenderOverwrite {
      */
     function overwriteSender($hookName, $hookArgs) {
         
-        $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
+        //$globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         $mail = $hookArgs[0];
-        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        //$mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        $mail->setFrom('peerprereview@iq.harvard.edu', 'Peer Pre-Review');
         return false; 
     }
 

--- a/pprOjsPlugin/settings/PPRPluginSettings.inc.php
+++ b/pprOjsPlugin/settings/PPRPluginSettings.inc.php
@@ -63,7 +63,7 @@ class PPRPluginSettings {
 
         'accessKeyLifeTime' => ['int', 30],
         'fileUploadTextOverrideEnabled' => ['bool', null],
-        'globalEmailSender' => ['string', 'peerprereview@iq.harvard.edu'],
+        'globalEmailSender' => ['string', 'peerprereview@pre-review.iq.harvard.edu'],
     );
     private $pprPlugin;
 

--- a/pprOjsPlugin/settings/PPRPluginSettings.inc.php
+++ b/pprOjsPlugin/settings/PPRPluginSettings.inc.php
@@ -63,6 +63,7 @@ class PPRPluginSettings {
 
         'accessKeyLifeTime' => ['int', 30],
         'fileUploadTextOverrideEnabled' => ['bool', null],
+        'globalEmailSender' => ['string', 'peerprereview@iq.harvard.edu'],
     );
     private $pprPlugin;
 
@@ -287,9 +288,12 @@ class PPRPluginSettings {
         return $this->getValue('reviewerSurveyHtml');
     }
 
-
     public function accessKeyLifeTime() {
         return $this->getValue('accessKeyLifeTime');
+    }
+
+    public function globalEmailSender() {
+        return $this->getValue('globalEmailSender');
     }
 
     private function getValue($propertyName) {

--- a/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
+++ b/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
@@ -93,6 +93,7 @@
 			{fbvElement type="checkbox" name="submissionApprovedEmailEnabled" label="plugins.generic.pprPlugin.settings.submissionApprovedEmailEnabled.label" id="submissionApprovedEmailEnabled" checked=$submissionApprovedEmailEnabled}
 			{fbvElement type="checkbox" name="submissionConfirmationContributorsEmailDisabled" label="plugins.generic.pprPlugin.settings.submissionConfirmationContributorsEmailDisabled.label" id="submissionConfirmationContributorsEmailDisabled" checked=$submissionConfirmationContributorsEmailDisabled}
 			{fbvElement type="checkbox" name="emailContributorsEnabled" label="plugins.generic.pprPlugin.settings.emailContributorsEnabled.label" id="emailContributorsEnabled" checked=$emailContributorsEnabled}
+			{fbvElement type="text" name="globalEmailSender" label="plugins.generic.pprPlugin.settings.globalEmailSender.label" id="globalEmailSender" value=$globalEmailSender}
 		{/fbvFormSection}
 
 		{fbvFormSection title="plugins.generic.pprPlugin.settings.section.tasks" list="true"}

--- a/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
+++ b/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
@@ -64,7 +64,7 @@ class PPRPluginSettingsTest extends PPRTestCase {
             'reviewerSurveyHtml' => [null, null],
             'accessKeyLifeTime' => [null, 30],
             'fileUploadTextOverrideEnabled' => [null, null],
-            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
+            'globalEmailSender' => [null, 'peerprereview@pre-review.iq.harvard.edu'],
         );
 
         foreach (PPRPluginSettings::CONFIG_VARS as $configVar => $varInfo) {

--- a/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
+++ b/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
@@ -64,6 +64,7 @@ class PPRPluginSettingsTest extends PPRTestCase {
             'reviewerSurveyHtml' => [null, null],
             'accessKeyLifeTime' => [null, 30],
             'fileUploadTextOverrideEnabled' => [null, null],
+            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRPluginSettings::CONFIG_VARS as $configVar => $varInfo) {

--- a/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
+++ b/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
@@ -17,6 +17,7 @@ class PPRReportPluginSettingsTest extends PPRTestCase {
             // fieldName => [methodName, defaultValue]
             'submissionsReviewsReportEnabled' => [null, null],
             'submissionsReviewsReportRecipients' => [null, []],
+            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRReportPluginSettings::CONFIG_VARS as $configVar => $varInfo) {

--- a/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
+++ b/pprReviewsReportPlugin/tests/src/settings/PPRReportPluginSettingsTest.php
@@ -17,7 +17,6 @@ class PPRReportPluginSettingsTest extends PPRTestCase {
             // fieldName => [methodName, defaultValue]
             'submissionsReviewsReportEnabled' => [null, null],
             'submissionsReviewsReportRecipients' => [null, []],
-            'globalEmailSender' => [null, 'peerprereview@iq.harvard.edu'],
         );
 
         foreach (PPRReportPluginSettings::CONFIG_VARS as $configVar => $varInfo) {


### PR DESCRIPTION
This pull request introduces a new feature to set a global email sender in the `pprOjsPlugin` and includes various changes to support this functionality. The most important changes involve adding a new service to overwrite the email sender, updating plugin settings, and modifying the user interface to accommodate the new feature.

### New Feature: Global Email Sender

* [`pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php`](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1R1-R36): Added a new service class `PPREmailSenderOverwrite` to overwrite the sender's email address using a global email sender configured in the plugin settings.
* [`pprOjsPlugin/PeerPreReviewProgramPlugin.inc.php`](diffhunk://#diff-ded891a6c05034b7ad74ba80a5d88363e72b6e8c3afe486fd25f1c4fd37597ecR100-R103): Registered the new `PPREmailSenderOverwrite` service to ensure it is called when emails are sent.

### Plugin Settings Update

* [`pprOjsPlugin/settings/PPRPluginSettings.inc.php`](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49R66): Added a new configuration variable `globalEmailSender` with a default value and a corresponding getter method. [[1]](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49R66) [[2]](diffhunk://#diff-c78e7005d8b151d76002a18fd73098b6e091861a6c152e714c366c1216d21d49L290-R298)
* [`pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php`](diffhunk://#diff-3e44c1734858923ebdd93754239006a8c75c4a9eed702ce20fddb313b6153e9bR67): Updated the test cases to include the new `globalEmailSender` configuration variable.

### User Interface Update

* [`pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl`](diffhunk://#diff-69b1417cd500e36cb657bd832c85dc6b4de23cca9e2e462a8b329ab5abd263b4R96): Added a new text input field for the `globalEmailSender` setting in the plugin settings form.

### Documentation Update

* [`docs/Sphinx-guides/source/features.md`](diffhunk://#diff-6b2ca0780df93069fedd7c13a22c9f5fea3125919e43c815aadd62343aceb8e3R66): Added a note about the new global email sender feature in the documentation.

### Localization Update

* [`pprOjsPlugin/locale/en_US/locale.po`](diffhunk://#diff-173adc05e1e6e91fe2ee1092fa2430ed0f75efd005dbd7126ec8fd8d9285fd5fR83-R85): Added a new localization entry for the `globalEmailSender` setting label.