### PR TITLE
Update email sender name and add reply-to address in PPREmailSenderOv…

### DIFF
--- a/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
+++ b/pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php
@@ -29,7 +29,8 @@ class PPREmailSenderOverwrite {
         $globalEmailSender = $this->pprPlugin->getPluginSettings()->globalEmailSender();
 
         $mail = $hookArgs[0];
-        $mail->setFrom($globalEmailSender, 'Peer Pre-Review');
+        $mail->setFrom($globalEmailSender, 'Harvard Peer Pre-Review');
+        $mail->setReplyTo($globalEmailSender, 'Harvard Peer Pre-Review');
         return false; 
     }
 


### PR DESCRIPTION
This pull request includes a change to the `PPREmailSenderOverwrite.inc.php` file to update the email sender details.

Email sender details update:

* [`pprOjsPlugin/services/email/PPREmailSenderOverwrite.inc.php`](diffhunk://#diff-7acf6e518c30ba9b945a75cc3ab413650292ddcabf96f261ba12a39db64878e1L32-R33): Modified the `overwriteSender` function to change the sender name to "Harvard Peer Pre-Review" and added a reply-to address with the same name.