### PR TITLE
Update Makefile to use 'docker compose', add port mapping in docker-c…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ ENV = env PPR_OJS_IMAGE=$(PPR_OJS_IMAGE)
 dev dev34: down up
 
 down:
-	cd environment && $(ENV) docker-compose down -v || :
+	cd environment && $(ENV) docker compose down -v || :
 
 up:
 	rm -rf environment/data/ojs/logs
-	cd environment && $(ENV) docker-compose up --build $(DETACHED_MODE)
+	cd environment && $(ENV) docker compose up --build $(DETACHED_MODE)
 
 release: new_version
 	$(eval RELEASE_VERSION = $(shell cat VERSION))

--- a/environment/docker-compose.yml
+++ b/environment/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"
+      - "9003:9003"
     volumes:
       - ./data/ojs/src:/tmp/ojs-src
       - ../pprOjsPlugin:/tmp/ojs-src/plugins/generic/pprOjsPlugin

--- a/environment/xdebug.ini
+++ b/environment/xdebug.ini
@@ -1,6 +1,7 @@
-zend_extension=xdebug
-
 [xdebug]
+zend_extension=xdebug.so
 xdebug.mode=develop,debug
 xdebug.client_host=host.docker.internal
 xdebug.start_with_request=yes
+xdebug.idekey=VSCODE
+xdebug.log=/var/log/xdebug.log


### PR DESCRIPTION
This pull request includes changes to the `Makefile`, `environment/docker-compose.yml`, and `environment/xdebug.ini` files to improve the development environment setup. The most important changes include updating the `Makefile` to use the correct Docker command syntax, adding a new port mapping in the Docker Compose configuration, and enhancing the Xdebug configuration.

Improvements to development environment setup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L23-R27): Updated the `down` and `up` targets to use the correct `docker compose` command syntax instead of the deprecated `docker-compose`.
* [`environment/docker-compose.yml`](diffhunk://#diff-6c498b449340207add8f4248dcab52cb1be92df5a360a652d73290e47714d519R63): Added a new port mapping for port 9003 to the `services` section to support connections.
* [`environment/xdebug.ini`](diffhunk://#diff-fd7b4fb7e7ac53ee84c28c49e28dbcfd58d0265d5b05dd35ad6f1e278074a834L1-R7): Enhanced the Xdebug configuration by specifying the `zend_extension` as `xdebug.so`, adding an `idekey` for VS Code, and setting a log file path for Xdebug logs.